### PR TITLE
feat: allow specifying bind interface

### DIFF
--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -92,6 +92,16 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   [self registerRouteHandlers:[self.class collectCommandHandlerClasses]];
   [self registerServerKeyRouteHandlers];
 
+  // Set the specific interface address if configured
+  NSString *serverHost = @"localhost";
+  NSString *interface = [FBConfiguration bindingServerInterface];
+  if (interface) {
+    [self.server setInterface:interface];
+    serverHost = interface;
+  } else {
+    interface = @"";
+  }
+
   NSRange serverPortRange = FBConfiguration.bindingPortRange;
   NSError *error;
   BOOL serverStarted = NO;
@@ -105,14 +115,14 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
       break;
     }
 
-    [FBLogger logFmt:@"Failed to start web server on port %ld with error %@", (long)port, [error description]];
+    [FBLogger logFmt:@"Failed to start web server on %@:%ld with error %@", interface, (long)port, [error description]];
   }
 
   if (!serverStarted) {
     [FBLogger logFmt:@"Last attempt to start web server failed with error %@", [error description]];
     abort();
   }
-  [FBLogger logFmt:@"%@http://%@:%d%@", FBServerURLBeginMarker, [XCUIDevice sharedDevice].fb_wifiIPAddress ?: @"localhost", [self.server port], FBServerURLEndMarker];
+  [FBLogger logFmt:@"%@http://%@:%d%@", FBServerURLBeginMarker, [XCUIDevice sharedDevice].fb_wifiIPAddress ?: serverHost, [self.server port], FBServerURLEndMarker];
 }
 
 - (void)initScreenshotsBroadcaster

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -113,6 +113,11 @@ extern NSString *const FBSnapshotMaxDepthKey;
 + (void)setScreenshotQuality:(NSUInteger)quality;
 
 /**
+ The HTTP Server bind interface
+ */
++ (NSString*)bindingServerInterface;
+
+/**
  The range of ports that the HTTP Server should attempt to bind on launch
  */
 + (NSRange)bindingPortRange;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -125,6 +125,13 @@ static UIInterfaceOrientation FBScreenshotOrientation;
     return self.bindingPortRangeFromArguments;
   }
 
+  // default did not want to be read directly using `integerForKey` despite being added to plist as an
+  // integer, but works fine loaded as string then converted
+  NSString *userPrefsPort = [[NSUserDefaults standardUserDefaults] objectForKey:@"Port"];
+  if (userPrefsPort != nil) {
+    return NSMakeRange([userPrefsPort integerValue] , 1);
+  }
+
   // Existence of USE_PORT in the environment implies the port range is managed by the launching process.
   if (NSProcessInfo.processInfo.environment[@"USE_PORT"] &&
       [NSProcessInfo.processInfo.environment[@"USE_PORT"] length] > 0) {
@@ -132,6 +139,29 @@ static UIInterfaceOrientation FBScreenshotOrientation;
   }
 
   return NSMakeRange(DefaultStartingPort, DefaultPortRange);
+}
+
++ (NSString*)bindingServerInterface
+{
+  // 'WebDriverAgent --interface 192.168.0.1' can be passed via the arguments to the process
+  NSString *addressFromArgs = self.bindingInterfaceFromArguments;
+  if (addressFromArgs != nil && addressFromArgs.length > 0) {
+    return addressFromArgs;
+  }
+
+  // Check if  user defaults plist contains "BindInterface"
+  NSString *addressFromUserDefaults = [[NSUserDefaults standardUserDefaults] objectForKey:@"BindInterface"];
+  if (addressFromUserDefaults != nil && addressFromArgs.length > 0) {
+    return addressFromUserDefaults;
+  }
+
+  // Check if the "USE_BIND_INTERFACE" environment variable is set
+  NSString *addressFromEnvironment = NSProcessInfo.processInfo.environment[@"USE_BIND_INTERFACE"];
+  if (addressFromEnvironment != nil && addressFromEnvironment.length > 0) {
+    return addressFromEnvironment;
+  }
+
+  return nil;
 }
 
 + (NSInteger)mjpegServerPort
@@ -593,6 +623,14 @@ static UIInterfaceOrientation FBScreenshotOrientation;
     return NSNotFound;
   }
   return port;
+}
+
++ (NSString*)bindingInterfaceFromArguments
+{
+  NSString *interface = [self valueFromArguments:NSProcessInfo.processInfo.arguments
+                                                 forKey: @"--interface"];
+
+  return interface;
 }
 
 + (NSRange)bindingPortRangeFromArguments

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -57,10 +57,16 @@ export class WebDriverAgent {
 
     this.setWDAPaths(args.bootstrapPath, args.agentPath);
 
+    this.wdaBindInterface = args.wdaBindInterface;
     this.wdaLocalPort = args.wdaLocalPort;
-    this.wdaRemotePort = ((this.isRealDevice ? args.wdaRemotePort : null) ?? args.wdaLocalPort)
-      || WDA_AGENT_PORT;
-    this.wdaBaseUrl = args.wdaBaseUrl || WDA_BASE_URL;
+    this.wdaRemotePort = args.wdaLocalPort || WDA_AGENT_PORT;
+    let wdaBaseUrl = WDA_BASE_URL;
+    if (this.wdaBindInterface) {
+	// Use wdaBindInterface if args.wdaBasUrl is not set
+        wdaBaseUrl = 'http://' + this.wdaBindInterface;
+        this.log.info(`Using bind interface: '${this.wdaBindInterface}'`);
+    }
+    this.wdaBaseUrl = args.wdaBaseUrl || wdaBaseUrl;
 
     this.prebuildWDA = args.prebuildWDA;
 
@@ -104,6 +110,7 @@ export class WebDriverAgent {
         usePrebuiltWDA: args.usePrebuiltWDA,
         updatedWDABundleId: this.updatedWDABundleId,
         launchTimeout: this.wdaLaunchTimeout,
+        wdaBindInterface: this.wdaBindInterface,
         wdaRemotePort: this.wdaRemotePort,
         useXctestrunFile: this.useXctestrunFile,
         derivedDataPath: args.derivedDataPath,
@@ -384,14 +391,18 @@ export class WebDriverAgent {
    *                 No error is raised if zero or negative number for the timeoutMs.
    */
   async launchWithPreinstalledWDA(sessionId) {
+    let bindInterface = '';
     const xctestEnv = {
       USE_PORT: this.wdaLocalPort || WDA_AGENT_PORT,
       WDA_PRODUCT_BUNDLE_IDENTIFIER: this.bundleIdForXctest
     };
+    if (this.wdaBindInterface) {
+      bindInterface = xctestEnv.USE_BIND_INTEFACE = this.wdaBindInterface;
+    }
     if (this.mjpegServerPort) {
       xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
     }
-    this.log.info('Launching WebDriverAgent on the device without xcodebuild');
+    this.log.info(`Launching WebDriverAgent on the device without xcodebuild on ${bindInterface}:${xctestEnv.USE_PORT}`);
     if (this.isRealDevice) {
       // Current method to launch WDA process can be done via 'xcrun devicectl',
       // but it has limitation about the WDA preinstalled package.

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -82,6 +82,7 @@ export class XcodeBuild {
     this.launchTimeout = args.launchTimeout;
 
     this.wdaRemotePort = args.wdaRemotePort;
+    this.wdaBindInterface = args.wdaBindInterface;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
     this.derivedDataPath = args.derivedDataPath;
@@ -309,6 +310,9 @@ export class XcodeBuild {
       USE_PORT: this.wdaRemotePort,
       WDA_PRODUCT_BUNDLE_IDENTIFIER: this.updatedWDABundleId || WDA_RUNNER_BUNDLE_ID,
     });
+    if (this.wdaBindInterface) {
+      env.USE_BIND_INTEFACE = this.wdaBindInterface;
+    }
     if (this.mjpegServerPort) {
       // https://github.com/appium/WebDriverAgent/pull/105
       env.MJPEG_SERVER_PORT = this.mjpegServerPort;

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -17,6 +17,7 @@ const defaultAgentPath = path.resolve(BOOTSTRAP_PATH, 'WebDriverAgent.xcodeproj'
 const customBootstrapPath = '/path/to/wda';
 const customAgentPath = '/path/to/some/agent/WebDriverAgent.xcodeproj';
 const customDerivedDataPath = '/path/to/some/agent/DerivedData/';
+const customBindInterface = '10.0.0.1';
 
 describe('Constructor', function () {
   let chai;
@@ -54,6 +55,14 @@ describe('Constructor', function () {
       derivedDataPath: customDerivedDataPath
     }, fakeConstructorArgs));
     agent.xcodebuild.derivedDataPath.should.eql(customDerivedDataPath);
+  });
+  it('should have custom bind address', function () {
+    let agent = new WebDriverAgent({}, _.defaults({
+      wdaBindInterface: customBindInterface,
+    }, fakeConstructorArgs));
+    agent.wdaBindInterface.should.eql(customBindInterface);
+    agent.wdaBaseUrl.should.eql('http://' + customBindInterface);
+    agent.xcodebuild.wdaBindInterface.should.eql(customBindInterface);
   });
 });
 
@@ -152,6 +161,14 @@ describe('get url', function () {
 
     const agent = new WebDriverAgent({}, args);
     agent.url.href.should.eql('https://127.0.0.1:8100/');
+  });
+  it('should use give WDA bind address', function () {
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.wdaBindInterface = customBindInterface;
+    args.wdaLocalPort = '9101';
+
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://' + customBindInterface + ':9101/');
   });
 });
 


### PR DESCRIPTION
This feature would allow multiple iOS simulators with WDA installed to be run on the same host by specifying different addresses to bind. 


- `--interface` flag (also `USE_BIND_INTERFACE` var) to specify a custom interface.
  - `--port` and `USE_PORT` existed before
- Allow configuring `Port` and `BindInterface` in a plist to be able to bind wda to a configurable netloc

For example, the following is possible:

- add loopback aliases `ifconfig lo0 alias 127.0.0.2`, .. `ifconfig lo0 alias 127.0.0.10`
- start multiple WDAs on `127.0.0.2:8100`, `127.0.0.3:8100`... `127.0.0.10:8100`